### PR TITLE
BREAKING CHANGE: v2.1.0 -> fix self-parent loops + multiplied gene lines

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,7 +59,7 @@ dependencies = [
 
 [[package]]
 name = "bed2gtf"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "clap",
  "flate2",
@@ -194,9 +194,9 @@ dependencies = [
 
 [[package]]
 name = "genepred"
-version = "0.0.11"
+version = "0.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09823e7cec06bf04ef2634f443e6c886b54ae0704893d74e0be903cdb285783d"
+checksum = "9cd51e7477eafba093bf369f6e2fdfd31c964967287988eae4d60364c15d0f53"
 dependencies = [
  "flate2",
  "memchr",
@@ -242,9 +242,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "memmap2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bed2gtf"
-version = "2.0.0"
+version = "2.1.0"
 authors = ["alejandrogzi <jose.gonzalesdezavala1@unmsm.edu.pe>"]
 edition = "2021"
 license = "MIT"
@@ -20,7 +20,7 @@ num_cpus = "1.16.0"
 flate2 = "1.0.28"
 libc = "0.2.101"
 thiserror = "2.0.18"
-genepred = { version = "0.0.11", features = ["gzip", "rayon", "mmap"] }
+genepred = { version = "0.0.15", features = ["gzip", "rayon", "mmap"] }
 
 [profile.release]
 lto = true

--- a/assets/chanegelog.md
+++ b/assets/chanegelog.md
@@ -1,0 +1,144 @@
+# Changelog
+
+## v2.1.0 - 2026-06-24
+
+### Fixed
+
+- Updated `genepred` from `0.0.11` to `0.0.15`, pulling in the GFF fix that
+  prevents unmapped transcripts from reusing their own ID as the parent gene ID.
+- Fixed GFF output for unmapped transcripts so `mRNA` records no longer form
+  self-parent loops; generated gene IDs now use the distinct `gene-<tx>` form.
+- Collapsed multiple isoforms from the same gene into a single emitted `gene`
+  feature instead of writing one gene row per transcript.
+- Recomputed emitted gene coordinates from the union of all isoform spans, so
+  the gene feature covers the full gene rather than only the leader transcript.
+- Preserved deterministic input order while parsing and rendering records in
+  parallel chunks.
+- Added regression coverage for GTF/GFF gene-line de-duplication, cross-window
+  isoform aggregation, span correction, and GFF self-parent prevention.
+
+### Changed
+
+- Bumped the crate version from `2.0.0` to `2.1.0`.
+- Refactored conversion rendering into a two-pass process: first gather records
+  and gene spans, then render ordered output windows.
+
+## v2.0.0 - 2026-03-19
+
+### Changed
+
+- Reworked the converter around `genepred`.
+- Added support for all BED input layouts handled by the current CLI.
+- Added GFF/GFF3 output support alongside GTF.
+- Added compressed input and output handling through the new conversion path.
+- Updated the README, project logo, and Nextflow module assets.
+- Added container and publish workflow support.
+- Removed the older implementation in favor of the new v2 architecture.
+
+## v1.9.3 - 2024-11-20
+
+### Fixed
+
+- Fixed issue #11.
+- Expanded gzip reader support.
+- Reported defective runtime lines through `log::error`.
+
+## v1.9.2 - 2024-04-12
+
+### Added
+
+- Added `--no-gene` support.
+- Added maximum memory usage reporting.
+
+### Changed
+
+- Refactored `BedRecord` handling.
+- Moved toward owned CLI module state.
+
+## v1.9.1 - 2024-02-20
+
+### Fixed
+
+- Disabled invalid UTR output paths.
+- Added coordinate guards to avoid invalid feature coordinates.
+- Fixed automatic version update handling.
+
+## v1.9.0 - 2024-01-04
+
+### Fixed
+
+- Fixed exon numbering, including reverse-strand indexing.
+- Fixed `--gz` flag handling.
+
+### Changed
+
+- Reworked buffered output writing through boxed writers.
+
+## v1.8.0 - 2023-11-27
+
+### Changed
+
+- Rebuilt the `BedRecord` model.
+- Added parallel conversion handlers.
+- Fixed gene coordinate handling in the parallel path.
+- Added a line-builder module.
+- Improved isoform parsing with partial `memchr` use.
+
+### Fixed
+
+- Added `PartialEq` support for `BedRecord`.
+- Fixed typos and documentation drift around the v1.8 changes.
+
+## v1.7.0 - 2023-10-17
+
+### Added
+
+- Added parsing error handling.
+- Added a pre-sorting step and early sorting support.
+
+### Changed
+
+- Updated documentation for the sorting workflow.
+
+## v1.6.0 - 2023-10-02
+
+### Fixed
+
+- Reported missing isoforms instead of unwrapping and aborting.
+
+## v1.5.0 - 2023-09-13
+
+### Changed
+
+- Updated output feature naming, including `five_prime_utr`.
+- Added logging improvements and new success messaging.
+- Added basic test modules.
+- Updated clap metadata.
+
+## v1.4.0 - 2023-08-19
+
+### Fixed
+
+- Fixed missing spaces in `exon_number` and ID attribute output.
+
+## v1.3.0 - 2023-08-18
+
+### Fixed
+
+- Fixed trailing spaces in transcript and UTR lines.
+
+## v1.2.0 - 2023-08-15
+
+### Changed
+
+- Reimplemented the core structs and conversion model.
+- Removed the old implementation.
+- Added project license metadata.
+
+## Initial history - 2023-08-02
+
+### Added
+
+- Bootstrapped the `bed2gtf` project.
+- Added initial Cargo metadata, README content, `.gitignore`, and isoform
+  documentation updates.

--- a/src/convert.rs
+++ b/src/convert.rs
@@ -1,3 +1,6 @@
+// Copyright (c) 2025 Alejandro Gonzalez-Irribarren <alejandrxgzi@gmail.com>
+// Distributed under the terms of the Apache License, Version 2.0.
+
 use crate::cli::{BedType, OutputFormat};
 use crate::config::{Config, InputSource, OutputTarget};
 use crate::detect::Compression;
@@ -9,6 +12,7 @@ use flate2::write::GzEncoder;
 use flate2::Compression as GzipLevel;
 use genepred::{Bed12, Bed3, Bed4, Bed5, Bed6, Bed8, Bed9, GenePred, Gff, Gtf, Reader};
 use rayon::prelude::*;
+use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::fs::File;
 use std::io::{self, BufWriter, Cursor, Read, Write};
@@ -107,9 +111,58 @@ where
     K: genepred::BedFormat,
 {
     let (reader, input_compression) = open_reader::<B>(config)?;
-    let mut outputs = reader
+
+    // Materialize every record in input order: parse chunks in parallel, then
+    // order them by chunk index before flattening.
+    let mut chunks = reader
         .par_chunks(config.chunks)?
-        .map(|(idx, chunk)| render_chunk::<K>(idx, chunk, isoforms))
+        .collect::<Vec<(usize, Vec<genepred::ReaderResult<GenePred>>)>>();
+    chunks.sort_by_key(|(idx, _)| *idx);
+
+    let mut records = Vec::new();
+    for (_, chunk) in chunks {
+        for record in chunk {
+            records.push(record?);
+        }
+    }
+
+    // First pass: aggregate each gene's span (minimum start, maximum end) across
+    // its isoforms and flag, for every record, whether it is the first
+    // occurrence of its gene (its gene "leader"). genepred emits a `gene` line
+    // per record, so without this only the leader keeps a single, span-correct
+    // gene line; the others have their duplicate gene line dropped during render.
+    let mut spans: HashMap<Vec<u8>, (u64, u64)> = HashMap::new();
+    let mut leaders = Vec::with_capacity(records.len());
+    for record in &records {
+        match resolve_gene_key(record, isoforms) {
+            Some(key) => match spans.entry(key) {
+                Entry::Occupied(mut slot) => {
+                    let (start, end) = slot.get_mut();
+                    *start = (*start).min(record.start);
+                    *end = (*end).max(record.end);
+                    leaders.push(false);
+                }
+                Entry::Vacant(slot) => {
+                    slot.insert((record.start, record.end));
+                    leaders.push(true);
+                }
+            },
+            None => leaders.push(true),
+        }
+    }
+
+    // Second pass: render windows of records in parallel, emitting exactly one
+    // span-corrected gene line per gene at its leader's position.
+    let window = config.chunks.max(1);
+    let mut outputs = (0..records.len())
+        .step_by(window)
+        .enumerate()
+        .collect::<Vec<_>>()
+        .into_par_iter()
+        .map(|(idx, base)| {
+            let end = (base + window).min(records.len());
+            render_window::<K>(idx, base, &records[base..end], &leaders, &spans, isoforms)
+        })
         .collect::<Vec<_>>();
 
     let mut merged = Vec::with_capacity(outputs.len());
@@ -169,29 +222,120 @@ fn open_stdin_reader() -> Result<(Box<dyn Read + Send>, Compression)> {
     }
 }
 
-/// Renders a chunk of GenePred records into GXF lines.
+/// Resolves the gene grouping key for a record, mirroring how genepred resolves
+/// the gene identifier it stamps on the emitted GXF lines.
+///
+/// Returns the mapped gene when an isoform mapping is supplied and matches the
+/// record name, the record name otherwise, or `None` when the record has no
+/// name (in which case it cannot be grouped and is treated as its own gene).
+///
+/// ```rust,ignore
+/// # use std::collections::HashMap;
+/// # let record: genepred::GenePred = todo!();
+/// let key = bed2gtf::convert::resolve_gene_key(&record, None);
+/// ```
+fn resolve_gene_key(
+    record: &GenePred,
+    isoforms: Option<&HashMap<String, String>>,
+) -> Option<Vec<u8>> {
+    let name = record.name.as_ref()?;
+    if let Some(mapping) = isoforms {
+        if let Ok(name_text) = std::str::from_utf8(name) {
+            if let Some(gene) = mapping.get(name_text) {
+                return Some(gene.as_bytes().to_vec());
+            }
+        }
+    }
+    Some(name.clone())
+}
+
+/// Returns true when a GXF line's feature column is `gene`.
+fn gene_feature_is_gene(line: &[u8]) -> bool {
+    line.split(|&byte| byte == b'\t').nth(2) == Some(b"gene".as_ref())
+}
+
+/// Rewrites the start and end coordinate columns of a GXF `gene` line.
+///
+/// The feature spans an entire gene, so its coordinates must reflect the union
+/// of all isoforms rather than the single record genepred derived it from.
+///
+/// ```rust,ignore
+/// let line = b"chr1\tTOGA2\tgene\t11\t20\t.\t+\t.\tgene_id \"g\";";
+/// let fixed = bed2gtf::convert::rewrite_gene_span(line, 5, 40);
+/// ```
+fn rewrite_gene_span(line: &[u8], start_col: u64, end_col: u64) -> Vec<u8> {
+    let start = start_col.to_string();
+    let end = end_col.to_string();
+    let mut out = Vec::with_capacity(line.len() + start.len() + end.len());
+    for (index, field) in line.split(|&byte| byte == b'\t').enumerate() {
+        if index > 0 {
+            out.push(b'\t');
+        }
+        match index {
+            3 => out.extend_from_slice(start.as_bytes()),
+            4 => out.extend_from_slice(end.as_bytes()),
+            _ => out.extend_from_slice(field),
+        }
+    }
+    out
+}
+
+/// Renders a window of GenePred records into GXF lines.
+///
+/// genepred emits a `gene` line for every record; this drops that per-record
+/// gene line and emits a single span-corrected gene line only when the record
+/// is its gene's leader (`leaders[base + offset]`).
 ///
 /// ```rust,ignore
 /// # use std::collections::HashMap;
 /// # let isoforms: Option<&HashMap<String, String>> = None;
-/// # let chunk: Vec<genepred::ReaderResult<genepred::GenePred>> = vec![];
-/// let (idx, buffer) = bed2gtf::convert::render_chunk::<genepred::Gtf>(0, chunk, isoforms)?;
+/// # let records: Vec<genepred::GenePred> = vec![];
+/// # let leaders = vec![true];
+/// # let spans = HashMap::new();
+/// let (idx, buffer) =
+///     bed2gtf::convert::render_window::<genepred::Gtf>(0, 0, &records, &leaders, &spans, isoforms)?;
 /// ```
-fn render_chunk<K>(
+fn render_window<K>(
     idx: usize,
-    chunk: Vec<genepred::ReaderResult<GenePred>>,
+    base: usize,
+    records: &[GenePred],
+    leaders: &[bool],
+    spans: &HashMap<Vec<u8>, (u64, u64)>,
     isoforms: Option<&HashMap<String, String>>,
 ) -> Result<(usize, Vec<u8>)>
 where
     K: genepred::BedFormat,
 {
-    let mut buffer = Vec::with_capacity(chunk.len().saturating_mul(256));
+    let mut buffer = Vec::with_capacity(records.len().saturating_mul(256));
     {
         let mut writer = BufWriter::with_capacity(128 * 1024, &mut buffer);
-        for record in chunk {
-            let record = record?;
-            for line in record.to_gxf::<K>(isoforms) {
-                writer.write_all(&line)?;
+        for (offset, record) in records.iter().enumerate() {
+            let lines = record.to_gxf::<K>(isoforms);
+            let mut lines = lines.iter();
+
+            // genepred always emits the per-record `gene` line first; drop it so
+            // a gene appears exactly once, contributed by its leader below.
+            let gene_line = lines.next();
+            debug_assert!(
+                gene_line
+                    .map(|line| gene_feature_is_gene(line))
+                    .unwrap_or(false),
+                "expected genepred to emit the gene feature as the first GXF line",
+            );
+
+            if leaders[base + offset] {
+                if let Some(gene_line) = gene_line {
+                    let (start, end) = resolve_gene_key(record, isoforms)
+                        .and_then(|key| spans.get(&key).copied())
+                        .unwrap_or((record.start, record.end));
+                    let corrected = rewrite_gene_span(gene_line, start.saturating_add(1), end);
+                    writer.write_all(&corrected)?;
+                    writer.write_all(b"\n")?;
+                }
+            }
+
+            for line in lines {
+                writer.write_all(line)?;
                 writer.write_all(b"\n")?;
             }
         }
@@ -273,4 +417,194 @@ fn validate_runtime_output(config: &Config, input_compression: Compression) -> R
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::run;
+    use crate::config::{Config, OutputTarget};
+    use crate::Args;
+    use clap::Parser;
+    use std::fs;
+    use std::path::PathBuf;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    /// Three isoforms of one gene at overlapping but distinct spans.
+    const BED: &str = "chr1\t1000\t2000\ttxA\t0\t+\t1000\t2000\t0,0,0\t1\t1000,\t0,\n\
+chr1\t1100\t2200\ttxB\t0\t+\t1100\t2200\t0,0,0\t1\t1100,\t0,\n\
+chr1\t900\t1800\ttxC\t0\t+\t900\t1800\t0,0,0\t1\t900,\t0,\n";
+
+    const ISOFORMS: &str = "txA\tGENE1\ntxB\tGENE1\ntxC\tGENE1\n";
+
+    fn temp_path(tag: &str, ext: &str) -> PathBuf {
+        let stamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("bed2gtf-convert-{tag}-{stamp}.{ext}"))
+    }
+
+    /// Runs a full conversion through the CLI surface and returns the output text.
+    fn convert(args: &[&str]) -> String {
+        let config = Config::from_args(Args::parse_from(args)).unwrap();
+        let OutputTarget::Path(output) = &config.output else {
+            panic!("test expects a file output target");
+        };
+        let path = output.path.clone();
+        run(&config).unwrap();
+        let text = fs::read_to_string(&path).unwrap();
+        let _ = fs::remove_file(&path);
+        text
+    }
+
+    fn gene_lines(text: &str) -> Vec<&str> {
+        text.lines()
+            .filter(|line| line.split('\t').nth(2) == Some("gene"))
+            .collect()
+    }
+
+    fn write_inputs(tag: &str) -> (PathBuf, PathBuf) {
+        let bed = temp_path(tag, "bed");
+        let iso = temp_path(tag, "tsv");
+        fs::write(&bed, BED).unwrap();
+        fs::write(&iso, ISOFORMS).unwrap();
+        (bed, iso)
+    }
+
+    #[test]
+    fn collapses_isoforms_into_single_gene_line_gtf() {
+        let (bed, iso) = write_inputs("gtf");
+        let out = temp_path("gtf", "gtf");
+        let text = convert(&[
+            "bed2gtf",
+            "-i",
+            bed.to_str().unwrap(),
+            "-I",
+            iso.to_str().unwrap(),
+            "-o",
+            out.to_str().unwrap(),
+        ]);
+        let _ = fs::remove_file(&bed);
+        let _ = fs::remove_file(&iso);
+
+        let genes = gene_lines(&text);
+        assert_eq!(genes.len(), 1, "expected one gene line, got: {genes:?}");
+        let fields: Vec<&str> = genes[0].split('\t').collect();
+        // Union span: 0-based min start 900 -> column 901; 1-based max end 2200.
+        assert_eq!(fields[3], "901");
+        assert_eq!(fields[4], "2200");
+        // The single gene line precedes all transcript rows for that gene.
+        let first_feature = text.lines().next().unwrap().split('\t').nth(2).unwrap();
+        assert_eq!(first_feature, "gene");
+    }
+
+    #[test]
+    fn collapses_isoforms_into_single_gene_line_gff() {
+        let (bed, iso) = write_inputs("gff");
+        let out = temp_path("gff", "gff");
+        let text = convert(&[
+            "bed2gtf",
+            "-i",
+            bed.to_str().unwrap(),
+            "-I",
+            iso.to_str().unwrap(),
+            "-o",
+            out.to_str().unwrap(),
+        ]);
+        let _ = fs::remove_file(&bed);
+        let _ = fs::remove_file(&iso);
+
+        let genes = gene_lines(&text);
+        assert_eq!(genes.len(), 1, "expected one gene line, got: {genes:?}");
+        let fields: Vec<&str> = genes[0].split('\t').collect();
+        assert_eq!(fields[3], "901");
+        assert_eq!(fields[4], "2200");
+    }
+
+    #[test]
+    fn dedup_holds_when_isoforms_span_separate_windows() {
+        let (bed, iso) = write_inputs("cross-window");
+        let out = temp_path("cross-window", "gtf");
+        // chunk size 1 places each isoform in its own parallel window, so a single
+        // gene line proves the leader is decided globally, not per window.
+        let text = convert(&[
+            "bed2gtf",
+            "-i",
+            bed.to_str().unwrap(),
+            "-I",
+            iso.to_str().unwrap(),
+            "-c",
+            "1",
+            "-o",
+            out.to_str().unwrap(),
+        ]);
+        let _ = fs::remove_file(&bed);
+        let _ = fs::remove_file(&iso);
+
+        let genes = gene_lines(&text);
+        assert_eq!(genes.len(), 1, "expected one gene line, got: {genes:?}");
+        let fields: Vec<&str> = genes[0].split('\t').collect();
+        assert_eq!(fields[3], "901");
+        assert_eq!(fields[4], "2200");
+    }
+
+    #[test]
+    fn keeps_one_gene_line_per_record_without_isoforms() {
+        let bed = temp_path("noiso", "bed");
+        fs::write(&bed, BED).unwrap();
+        let out = temp_path("noiso", "gtf");
+        let text = convert(&[
+            "bed2gtf",
+            "-i",
+            bed.to_str().unwrap(),
+            "-o",
+            out.to_str().unwrap(),
+        ]);
+        let _ = fs::remove_file(&bed);
+
+        // Each transcript is its own gene, so the per-record gene line is correct.
+        assert_eq!(gene_lines(&text).len(), 3);
+    }
+
+    /// In GFF, an unmapped transcript must not reuse its own id as the gene id:
+    /// that collided the `gene`/`mRNA` `ID`s and made the mRNA its own `Parent`
+    /// (a self-loop for GFF3 parsers). genepred now synthesizes `gene-<tx>`.
+    #[test]
+    fn gff_without_isoforms_uses_distinct_gene_and_transcript_ids() {
+        let bed = temp_path("noiso-gff", "bed");
+        fs::write(&bed, BED).unwrap();
+        let out = temp_path("noiso-gff", "gff");
+        let text = convert(&[
+            "bed2gtf",
+            "-i",
+            bed.to_str().unwrap(),
+            "-o",
+            out.to_str().unwrap(),
+        ]);
+        let _ = fs::remove_file(&bed);
+
+        let attr = |line: &str, key: &str| -> Option<String> {
+            line.split('\t')
+                .nth(8)?
+                .split(';')
+                .find_map(|a| a.strip_prefix(key).map(str::to_string))
+        };
+
+        let mut mrnas = 0;
+        for line in text.lines() {
+            if line.split('\t').nth(2) == Some("mRNA") {
+                mrnas += 1;
+                let id = attr(line, "ID=").expect("mRNA has ID");
+                let parent = attr(line, "Parent=").expect("mRNA has Parent");
+                assert_ne!(parent, id, "mRNA must not be its own parent: {line}");
+                assert_eq!(parent, format!("gene-{id}"), "line: {line}");
+            }
+        }
+        assert_eq!(mrnas, 3);
+
+        assert!(gene_lines(&text)
+            .iter()
+            .filter_map(|line| attr(line, "ID="))
+            .all(|gene_id| gene_id.starts_with("gene-")));
+    }
 }


### PR DESCRIPTION
### Fixed

- Updated `genepred` from `0.0.11` to `0.0.15`, pulling in the GFF fix that
  prevents unmapped transcripts from reusing their own ID as the parent gene ID.
- Fixed GFF output for unmapped transcripts so `mRNA` records no longer form
  self-parent loops; generated gene IDs now use the distinct `gene-<tx>` form.
- Collapsed multiple isoforms from the same gene into a single emitted `gene`
  feature instead of writing one gene row per transcript.
- Recomputed emitted gene coordinates from the union of all isoform spans, so
  the gene feature covers the full gene rather than only the leader transcript.
- Preserved deterministic input order while parsing and rendering records in
  parallel chunks.
- Added regression coverage for GTF/GFF gene-line de-duplication, cross-window
  isoform aggregation, span correction, and GFF self-parent prevention.

### Changed

- Bumped the crate version from `2.0.0` to `2.1.0`.
- Refactored conversion rendering into a two-pass process: first gather records
  and gene spans, then render ordered output windows.